### PR TITLE
refactor(flatter): remove superfluous signing step

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -74045,14 +74045,6 @@ const BUILD_BUNDLE_INPUTS = [
     'gpg-sign',
 ];
 
-const BUILD_SIGN_INPUTS = [
-    'gpg-sign',
-];
-
-const BUILD_UPDATE_REPO_INPUTS = [
-    'gpg-sign',
-];
-
 
 /**
  * Parse and coalesce arguments for a command-line program.
@@ -74155,45 +74147,6 @@ async function buildBundle(location, fileName, name, branch = 'master', args = [
         fileName,
         name,
         branch,
-    ]);
-}
-
-/**
- * Sign a Flatpak repository.
- *
- * @param {PathLike} locateion - A path to a Flatpak repository
- * @param {string[]} [args] - Command-line options for `flatpak build-sign`
- * @returns {Promise<>} A promise for the operation
- */
-async function buildSign(location, args = []) {
-    core.debug(`${location}, ${args}`);
-
-    const signArgs = parseArguments(BUILD_SIGN_INPUTS, args);
-
-    await exec.exec('flatpak', [
-        'build-sign',
-        ...signArgs,
-        location,
-    ]);
-}
-
-
-/**
- * Update repository metadata.
- *
- * @param {PathLike} locateion - A path to a Flatpak repository
- * @param {string[]} [args] - Command-line options for `flatpak build-sign`
- * @returns {Promise<>} A promise for the operation
- */
-async function buildUpdateRepo(location, args = ['--prune']) {
-    core.debug(`${location}, ${args}`);
-
-    const signArgs = parseArguments(BUILD_UPDATE_REPO_INPUTS, args);
-
-    await exec.exec('flatpak', [
-        'build-update-repo',
-        ...signArgs,
-        location,
     ]);
 }
 
@@ -74482,15 +74435,6 @@ async function run() {
         } catch (e) {
             core.warning(`Failed to build "${manifest}": ${e.message}`);
         }
-
-        core.endGroup();
-    }
-
-    if (core.getInput('gpg-sign')) {
-        core.startGroup('Signing Flatpak repository...');
-
-        await buildSign(repo);
-        await buildUpdateRepo(repo);
 
         core.endGroup();
     }

--- a/src/flatpak.js
+++ b/src/flatpak.js
@@ -12,8 +12,6 @@ export  {
     parseManifest,
     builder,
     buildBundle,
-    buildSign,
-    buildUpdateRepo,
 };
 
 
@@ -31,14 +29,6 @@ const BUILDER_INPUTS = [
 ];
 
 const BUILD_BUNDLE_INPUTS = [
-    'gpg-sign',
-];
-
-const BUILD_SIGN_INPUTS = [
-    'gpg-sign',
-];
-
-const BUILD_UPDATE_REPO_INPUTS = [
     'gpg-sign',
 ];
 
@@ -144,45 +134,6 @@ async function buildBundle(location, fileName, name, branch = 'master', args = [
         fileName,
         name,
         branch,
-    ]);
-}
-
-/**
- * Sign a Flatpak repository.
- *
- * @param {PathLike} locateion - A path to a Flatpak repository
- * @param {string[]} [args] - Command-line options for `flatpak build-sign`
- * @returns {Promise<>} A promise for the operation
- */
-async function buildSign(location, args = []) {
-    core.debug(`${location}, ${args}`);
-
-    const signArgs = parseArguments(BUILD_SIGN_INPUTS, args);
-
-    await exec.exec('flatpak', [
-        'build-sign',
-        ...signArgs,
-        location,
-    ]);
-}
-
-
-/**
- * Update repository metadata.
- *
- * @param {PathLike} locateion - A path to a Flatpak repository
- * @param {string[]} [args] - Command-line options for `flatpak build-sign`
- * @returns {Promise<>} A promise for the operation
- */
-async function buildUpdateRepo(location, args = ['--prune']) {
-    core.debug(`${location}, ${args}`);
-
-    const signArgs = parseArguments(BUILD_UPDATE_REPO_INPUTS, args);
-
-    await exec.exec('flatpak', [
-        'build-update-repo',
-        ...signArgs,
-        location,
     ]);
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -142,15 +142,6 @@ async function run() {
         core.endGroup();
     }
 
-    if (core.getInput('gpg-sign')) {
-        core.startGroup('Signing Flatpak repository...');
-
-        await flatpak.buildSign(repo);
-        await flatpak.buildUpdateRepo(repo);
-
-        core.endGroup();
-    }
-
     if (core.getBooleanInput('flatpakrepo')) {
         core.startGroup('Generating .flatpakrepo...');
 


### PR DESCRIPTION
The signing is already performed by `flatpak-builder`.