### PR TITLE
generate flatpakrepo without deploying

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,14 @@ inputs:
       Generate a flatpakrepo file for a self-hosted repo.
     default: false
     required: false
+  flatpakrepo-url:
+    description: >
+      Url to the self-hosted repo
+    required: false
+  flatpakrepo-icon:
+    description: >
+      Url for the self-hosted repo icon
+    required: false
   upload-pages-artifact:
     description: >
       Upload the repository as a GitHub Pages artifact.

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,11 @@ inputs:
       Upload each application as an artifact.
     default: false
     required: false
+  generate-flatpakrepo:
+    description: >
+      Generate a flatpakrepo file for a self-hosted repo.
+    default: false
+    required: false
   upload-pages-artifact:
     description: >
       Upload the repository as a GitHub Pages artifact.

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,10 @@ inputs:
       Generate a flatpakrepo file for a self-hosted repo.
     default: false
     required: false
+  flatpakrepo-title:
+    description: >
+      Title of the self-hosted repo
+    required: false
   flatpakrepo-url:
     description: >
       Url to the self-hosted repo

--- a/src/flatter.js
+++ b/src/flatter.js
@@ -129,11 +129,11 @@ async function generateDescription(directory) {
     const {repository} = github.context.payload;
 
     const metadata = {
-        Title: repository.name,
+        Title: core.getInput('flatpakrepo-title') || repository.name,
         Description: repository.description,
         Url: core.getInput('flatpakrepo-url') || `https://${repository.owner.login}.github.io/${repository.name}`,
         Homepage: repository.homepage || repository.html_url,
-        Icon: core.getInput('flatpakrepo-icon') || 'https://raw.githubusercontent.com/flatpak/flatpak/main/flatpak.png',
+        Icon: core.getInput('flatpakrepo.icon') || 'https://raw.githubusercontent.com/flatpak/flatpak/main/flatpak.png',
     };
 
     /* Append the GPG Public Key */

--- a/src/flatter.js
+++ b/src/flatter.js
@@ -9,20 +9,16 @@ import * as cache from '@actions/cache';
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 import * as github from '@actions/github';
-import * as yaml from 'js-yaml';
 import { spawn } from 'child_process';
+import * as yaml from 'js-yaml';
 import { homedir } from 'os';
 
 
 export {
     buildApplication,
     bundleApplication,
-    checkApplication,
-    testApplication,
-    generateDescription,
-    updateRepositoryMetadata,
-    restoreCache,
-    saveCache,
+    checkApplication, generateDescription, restoreCache,
+    saveCache, testApplication, updateRepositoryMetadata
 };
 
 
@@ -135,9 +131,9 @@ async function generateDescription(directory) {
     const metadata = {
         Title: repository.name,
         Description: repository.description,
-        Url: `https://${repository.owner.login}.github.io/${repository.name}`,
+        Url: core.getInput('flatpakrepo-url') || `https://${repository.owner.login}.github.io/${repository.name}`,
         Homepage: repository.homepage || repository.html_url,
-        Icon: 'https://raw.githubusercontent.com/flatpak/flatpak/main/flatpak.png',
+        Icon: core.getInput('flatpakrepo-icon') || 'https://raw.githubusercontent.com/flatpak/flatpak/main/flatpak.png',
     };
 
     /* Append the GPG Public Key */

--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,6 @@ async function run() {
     const repository = `${process.cwd()}/repo`;
     core.setOutput('repository', repository);
 
-
     /*
      * Build the Flatpak manifests
      */
@@ -82,6 +81,27 @@ async function run() {
     if (process.exitCode === core.ExitCode.Failure)
         return;
 
+
+    /*
+     * Generate flatpakrepo
+     */
+    if (core.getBooleanInput('generate-flatpakrepo') || core.getBooleanInput('upload-pages-artifact')) {
+        core.startGroup('Generate flatpakrepo...');
+
+        try {
+            // Generate a .flatpakrepo file
+            await flatter.generateDescription(repository);
+
+        } catch (e) {
+            core.setFailed(`Failed to generate artifact: ${e.message}`);
+        }
+
+        core.endGroup();
+
+        if (process.exitCode === core.ExitCode.Failure)
+            return;
+    }
+
     /*
      * GitHub Pages Artifact
      */
@@ -89,9 +109,6 @@ async function run() {
         core.startGroup('Uploading GitHub Pages artifact...');
 
         try {
-            // Generate a .flatpakrepo file
-            await flatter.generateDescription(repository);
-
             // Copy extra files to the repository directory
             await includeFiles(repository);
 


### PR DESCRIPTION
I also want to deploy docs to my github-pages, alongside the self-hosted flatpak repo.

If I understand correctly, you can only upload a single pages artifact. So with this PR can just generate the index.flatpakrepo, without immediately uploading it.

Quick question: for this to work, do you need the whole 'repository' artifact, or is only the index.flatpakrepo file sufficient?