### PR TITLE
ci: drop remote argument from install step

### DIFF
--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -35,17 +35,14 @@ jobs:
           - name: freedesktop
             tag: 22.08
             packages: org.freedesktop.Platform/x86_64/22.08 org.freedesktop.Sdk/x86_64/22.08 org.freedesktop.Platform/aarch64/22.08 org.freedesktop.Sdk/aarch64/22.08
-            remote: flathub
 
           - name: freedesktop
             tag: 23.08
             packages: org.freedesktop.Platform/x86_64/23.08 org.freedesktop.Sdk/x86_64/23.08 org.freedesktop.Platform/aarch64/23.08 org.freedesktop.Sdk/aarch64/23.08
-            remote: flathub
 
           - name: rust
             tag: 23.08
             packages: org.freedesktop.Platform/x86_64/23.08 org.freedesktop.Sdk/x86_64/23.08 org.freedesktop.Platform/aarch64/23.08 org.freedesktop.Sdk/aarch64/23.08 org.freedesktop.Sdk.Extension.llvm17/x86_64/23.08 org.freedesktop.Sdk.Extension.rust-stable/x86_64/23.08 org.freedesktop.Sdk.Extension.llvm17/aarch64/23.08 org.freedesktop.Sdk.Extension.rust-stable/aarch64/23.08
-            remote: flathub
 
           # elementaryOS
           #
@@ -54,7 +51,6 @@ jobs:
           - name: elementary
             tag: juno-22.08
             packages: io.elementary.BaseApp//juno-22.08 org.freedesktop.Platform//22.08 org.freedesktop.Sdk//22.08
-            remote: flathub
 
           # GNOME
           #
@@ -63,27 +59,22 @@ jobs:
           - name: gnome
             tag: 45
             packages: org.gnome.Platform/x86_64/45 org.gnome.Sdk/x86_64/45 org.gnome.Platform/aarch64/45 org.gnome.Sdk/aarch64/45
-            remote: flathub
 
           - name: gnome
             tag: 46
             packages: org.gnome.Platform/x86_64/46 org.gnome.Sdk/x86_64/46 org.gnome.Platform/aarch64/46 org.gnome.Sdk/aarch64/46
-            remote: flathub
 
           - name: gnome
             tag: master
             packages: org.gnome.Platform/x86_64/master org.gnome.Sdk/x86_64/master org.gnome.Platform/aarch64/master org.gnome.Sdk/aarch64/master
-            remote: gnome-nightly
 
           - name: gnome-rust
             tag: 45
             packages: org.freedesktop.Sdk.Extension.llvm17/x86_64/23.08 org.freedesktop.Sdk.Extension.rust-stable/x86_64/23.08 org.gnome.Platform/x86_64/45 org.gnome.Sdk/x86_64/45 org.freedesktop.Sdk.Extension.llvm17/aarch64/23.08 org.freedesktop.Sdk.Extension.rust-stable/aarch64/23.08 org.gnome.Platform/aarch64/45 org.gnome.Sdk/aarch64/45
-            remote: flathub
 
           - name: gnome-rust
             tag: 46
             packages: org.freedesktop.Sdk.Extension.llvm17/x86_64/23.08 org.freedesktop.Sdk.Extension.rust-stable/x86_64/23.08 org.gnome.Platform/x86_64/46 org.gnome.Sdk/x86_64/46 org.freedesktop.Sdk.Extension.llvm17/aarch64/23.08 org.freedesktop.Sdk.Extension.rust-stable/aarch64/23.08 org.gnome.Platform/aarch64/46 org.gnome.Sdk/aarch64/46
-            remote: flathub
 
           # Workbench
           #
@@ -92,7 +83,6 @@ jobs:
           - name: workbench
             tag: master
             packages: org.freedesktop.Sdk.Extension.llvm16/x86_64/23.08 org.freedesktop.Sdk.Extension.node18/x86_64/23.08 org.freedesktop.Sdk.Extension.typescript/x86_64/23.08 org.freedesktop.Sdk.Extension.rust-stable/x86_64/23.08 org.freedesktop.Sdk.Extension.vala/x86_64/23.08 org.gnome.Platform/x86_64/master org.gnome.Sdk/x86_64/master org.freedesktop.Sdk.Extension.llvm16/aarch64/23.08 org.freedesktop.Sdk.Extension.node18/aarch64/23.08 org.freedesktop.Sdk.Extension.typescript/aarch64/23.08 org.freedesktop.Sdk.Extension.rust-stable/aarch64/23.08 org.freedesktop.Sdk.Extension.vala/aarch64/23.08 org.gnome.Platform/aarch64/master org.gnome.Sdk/aarch64/master
-            remote: gnome-nightly
 
           # KDE
           #
@@ -101,7 +91,6 @@ jobs:
           - name: kde
             tag: 5.15-23.08
             packages: org.kde.Platform/x86_64/5.15-23.08 org.kde.Sdk/x86_64/5.15-23.08 org.kde.Platform/aarch64/5.15-23.08 org.kde.Sdk/aarch64/5.15-23.08
-            remote: flathub
       fail-fast: false
 
     steps:
@@ -146,7 +135,6 @@ jobs:
           FROM localhost:5000/flatter-base:latest
 
           RUN --security=insecure flatpak install -y --noninteractive \
-                                                  ${{ matrix.runtime.remote }} \
                                                   ${{ matrix.runtime.packages }}
           EOF
 


### PR DESCRIPTION
We already setup all the required remotes, and install by specific ref, so just drop the remote argument.