### PR TITLE
feat: use Flathub's patched flatpak-builder

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Spell Check
         uses: codespell-project/actions-codespell@master
         with:
-          skip: .git,dist
+          skip: .git,build-aux,dist
 
   codeql:
     name: CodeQL

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@
 
 FROM registry.fedoraproject.org/fedora:latest
 
+COPY build-aux/ /build-aux/
+
 # Notes:
 #   - docker:          docker/setup-qemu-action
 #   - python3-*:       flatpak/flatpak-external-data-checker
@@ -14,14 +16,54 @@ RUN dnf install -y ccache flatpak flatpak-builder git git-lfs \
                    python3-{aiohttp,apt,editorconfig,github,gobject,jsonschema,lxml,magic,packaging,pyelftools,ruamel-yaml,semver,toml} \
                    rsync \
                    zstd && \
+    dnf install -y 'dnf-command(builddep)' && \
+    dnf builddep -y appstream flatpak-builder && \
     dnf clean all && rm -rf /var/cache/dnf
 
+#
+# AppStream & Flatpak Builder with compose pass-through
+#
+RUN git clone https://github.com/ximion/appstream.git \
+              --branch v1.0.3 \
+              --single-branch && \
+    cd appstream && \
+    git apply /build-aux/patches/appstream-demotion-allowlist.patch && \
+    git apply /build-aux/patches/appstream-compose-default-propagate-custom.patch && \
+    git apply /build-aux/patches/asc-hint-tags-silence-some-vague-validation-errors.patch && \
+    git apply /build-aux/patches/compose-seperate-file-read-error.patch && \
+    git apply /build-aux/patches/appstream-compose-lang-symlinks.patch && \
+    meson setup -Dapidocs=false \
+                -Dgir=false \
+                -Dcompose=true \
+                _build && \
+    meson install -C _build
+
+RUN git clone https://github.com/flatpak/flatpak-builder.git \
+              --branch 1.4.4 \
+              --single-branch && \
+    cd flatpak-builder && \
+    git apply /build-aux/patches/flatpak-builder-lfs.patch && \
+    git apply /build-aux/patches/flatpak-builder-appstream-cli-urls.patch && \
+    git apply /build-aux/patches/flatpak-builder-disable-compressed-downloads.patch && \
+    meson setup -Ddocs=disabled \
+                -Dfuse=2 \
+                -Dtests=false \
+                _build && \
+    meson install -C _build
+
+#
+# Flatpak Dependency Checker
+#
 RUN git clone https://github.com/flathub/flatpak-external-data-checker.git \
               --branch master \
               --single-branch && \
     ln -sf $(pwd)/flatpak-external-data-checker/flatpak-external-data-checker \
            /usr/bin/flatpak-external-data-checker
 
+#
+# Default Remotes
+#
 RUN flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && \
     flatpak remote-add --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo && \
     flatpak remote-add --if-not-exists gnome-nightly https://nightly.gnome.org/gnome-nightly.flatpakrepo
+

--- a/LICENSES/LGPL-2.1-or-later.txt
+++ b/LICENSES/LGPL-2.1-or-later.txt
@@ -1,0 +1,176 @@
+GNU LESSER GENERAL PUBLIC LICENSE
+
+Version 2.1, February 1999
+
+Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts as the successor of the GNU Library Public License, version 2, hence the version number 2.1.]
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public Licenses are intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users.
+
+This license, the Lesser General Public License, applies to some specially designated software packages--typically libraries--of the Free Software Foundation and other authors who decide to use it. You can use it too, but we suggest you first think carefully about whether this license or the ordinary General Public License is the better strategy to use in any particular case, based on the explanations below.
+
+When we speak of free software, we are referring to freedom of use, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish); that you receive source code or can get it if you want it; that you can change the software and use pieces of it in new free programs; and that you are informed that you can do these things.
+
+To protect your rights, we need to make restrictions that forbid distributors to deny you these rights or to ask you to surrender these rights. These restrictions translate to certain responsibilities for you if you distribute copies of the library or if you modify it.
+
+For example, if you distribute copies of the library, whether gratis or for a fee, you must give the recipients all the rights that we gave you. You must make sure that they, too, receive or can get the source code. If you link other code with the library, you must provide complete object files to the recipients, so that they can relink them with the library after making changes to the library and recompiling it. And you must show them these terms so they know their rights.
+
+We protect your rights with a two-step method: (1) we copyright the library, and (2) we offer you this license, which gives you legal permission to copy, distribute and/or modify the library.
+
+To protect each distributor, we want to make it very clear that there is no warranty for the free library. Also, if the library is modified by someone else and passed on, the recipients should know that what they have is not the original version, so that the original author's reputation will not be affected by problems that might be introduced by others.
+
+Finally, software patents pose a constant threat to the existence of any free program. We wish to make sure that a company cannot effectively restrict the users of a free program by obtaining a restrictive license from a patent holder. Therefore, we insist that any patent license obtained for a version of the library must be consistent with the full freedom of use specified in this license.
+
+Most GNU software, including some libraries, is covered by the ordinary GNU General Public License. This license, the GNU Lesser General Public License, applies to certain designated libraries, and is quite different from the ordinary General Public License. We use this license for certain libraries in order to permit linking those libraries into non-free programs.
+
+When a program is linked with a library, whether statically or using a shared library, the combination of the two is legally speaking a combined work, a derivative of the original library. The ordinary General Public License therefore permits such linking only if the entire combination fits its criteria of freedom. The Lesser General Public License permits more lax criteria for linking other code with the library.
+
+We call this license the "Lesser" General Public License because it does Less to protect the user's freedom than the ordinary General Public License. It also provides other free software developers Less of an advantage over competing non-free programs. These disadvantages are the reason we use the ordinary General Public License for many libraries. However, the Lesser license provides advantages in certain special circumstances.
+
+For example, on rare occasions, there may be a special need to encourage the widest possible use of a certain library, so that it becomes a de-facto standard. To achieve this, non-free programs must be allowed to use the library. A more frequent case is that a free library does the same job as widely used non-free libraries. In this case, there is little to gain by limiting the free library to free software only, so we use the Lesser General Public License.
+
+In other cases, permission to use a particular library in non-free programs enables a greater number of people to use a large body of free software. For example, permission to use the GNU C Library in non-free programs enables many more people to use the whole GNU operating system, as well as its variant, the GNU/Linux operating system.
+
+Although the Lesser General Public License is Less protective of the users' freedom, it does ensure that the user of a program that is linked with the Library has the freedom and the wherewithal to run that program using a modified version of the Library.
+
+The precise terms and conditions for copying, distribution and modification follow. Pay close attention to the difference between a "work based on the library" and a "work that uses the library". The former contains code derived from the library, whereas the latter must be combined with the library in order to run.
+
+GNU LESSER GENERAL PUBLIC LICENSE
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License Agreement applies to any software library or other program which contains a notice placed by the copyright holder or other authorized party saying it may be distributed under the terms of this Lesser General Public License (also called "this License"). Each licensee is addressed as "you".
+
+A "library" means a collection of software functions and/or data prepared so as to be conveniently linked with application programs (which use some of those functions and data) to form executables.
+
+The "Library", below, refers to any such software library or work which has been distributed under these terms. A "work based on the Library" means either the Library or any derivative work under copyright law: that is to say, a work containing the Library or a portion of it, either verbatim or with modifications and/or translated straightforwardly into another language. (Hereinafter, translation is included without limitation in the term "modification".)
+
+"Source code" for a work means the preferred form of the work for making modifications to it. For a library, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the library.
+
+Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running a program using the Library is not restricted, and output from such a program is covered only if its contents constitute a work based on the Library (independent of the use of the Library in a tool for writing it). Whether that is true depends on what the Library does and what the program that uses the Library does.
+
+1. You may copy and distribute verbatim copies of the Library's complete source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and distribute a copy of this License along with the Library.
+
+You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Library or any portion of it, thus forming a work based on the Library, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+     a) The modified work must itself be a software library.
+
+     b) You must cause the files modified to carry prominent notices stating that you changed the files and the date of any change.
+
+     c) You must cause the whole of the work to be licensed at no charge to all third parties under the terms of this License.
+
+     d) If a facility in the modified Library refers to a function or a table of data to be supplied by an application program that uses the facility, other than as an argument passed when the facility is invoked, then you must make a good faith effort to ensure that, in the event an application does not supply such function or table, the facility still operates, and performs whatever part of its purpose remains meaningful.
+
+(For example, a function in a library to compute square roots has a purpose that is entirely well-defined independent of the application. Therefore, Subsection 2d requires that any application-supplied function or table used by this function must be optional: if the application does not supply it, the square root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Library, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Library, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library with the Library (or with a work based on the Library) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+3. You may opt to apply the terms of the ordinary GNU General Public License instead of this License to a given copy of the Library. To do this, you must alter all the notices that refer to this License, so that they refer to the ordinary GNU General Public License, version 2, instead of to this License. (If a newer version than version 2 of the ordinary GNU General Public License has appeared, then you can specify that version instead if you wish.) Do not make any other change in these notices.
+
+Once this change is made in a given copy, it is irreversible for that copy, so the ordinary GNU General Public License applies to all subsequent copies and derivative works made from that copy.
+
+This option is useful when you wish to copy part of the code of the Library into a program that is not a library.
+
+4. You may copy and distribute the Library (or a portion or derivative of it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange.
+
+If distribution of object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place satisfies the requirement to distribute the source code, even though third parties are not compelled to copy the source along with the object code.
+
+5. A program that contains no derivative of any portion of the Library, but is designed to work with the Library by being compiled or linked with it, is called a "work that uses the Library". Such a work, in isolation, is not a derivative work of the Library, and therefore falls outside the scope of this License.
+
+However, linking a "work that uses the Library" with the Library creates an executable that is a derivative of the Library (because it contains portions of the Library), rather than a "work that uses the library". The executable is therefore covered by this License. Section 6 states terms for distribution of such executables.
+
+When a "work that uses the Library" uses material from a header file that is part of the Library, the object code for the work may be a derivative work of the Library even though the source code is not. Whether this is true is especially significant if the work can be linked without the Library, or if the work is itself a library. The threshold for this to be true is not precisely defined by law.
+
+If such an object file uses only numerical parameters, data structure layouts and accessors, and small macros and small inline functions (ten lines or less in length), then the use of the object file is unrestricted, regardless of whether it is legally a derivative work. (Executables containing this object code plus portions of the Library will still fall under Section 6.)
+
+Otherwise, if the work is a derivative of the Library, you may distribute the object code for the work under the terms of Section 6. Any executables containing that work also fall under Section 6, whether or not they are linked directly with the Library itself.
+
+6. As an exception to the Sections above, you may also combine or link a "work that uses the Library" with the Library to produce a work containing portions of the Library, and distribute that work under terms of your choice, provided that the terms permit modification of the work for the customer's own use and reverse engineering for debugging such modifications.
+
+You must give prominent notice with each copy of the work that the Library is used in it and that the Library and its use are covered by this License. You must supply a copy of this License. If the work during execution displays copyright notices, you must include the copyright notice for the Library among them, as well as a reference directing the user to the copy of this License. Also, you must do one of these things:
+
+     a) Accompany the work with the complete corresponding machine-readable source code for the Library including whatever changes were used in the work (which must be distributed under Sections 1 and 2 above); and, if the work is an executable linked with the Library, with the complete machine-readable "work that uses the Library", as object code and/or source code, so that the user can modify the Library and then relink to produce a modified executable containing the modified Library. (It is understood that the user who changes the contents of definitions files in the Library will not necessarily be able to recompile the application to use the modified definitions.)
+
+     b) Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is one that (1) uses at run time a copy of the library already present on the user's computer system, rather than copying library functions into the executable, and (2) will operate properly with a modified version of the library, if the user installs one, as long as the modified version is interface-compatible with the version that the work was made with.
+
+     c) Accompany the work with a written offer, valid for at least three years, to give the same user the materials specified in Subsection 6a, above, for a charge no more than the cost of performing this distribution.
+
+     d) If distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above specified materials from the same place.
+
+     e) Verify that the user has already received a copy of these materials or that you have already sent this user a copy.
+
+For an executable, the required form of the "work that uses the Library" must include any data and utility programs needed for reproducing the executable from it. However, as a special exception, the materials to be distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+It may happen that this requirement contradicts the license restrictions of other proprietary libraries that do not normally accompany the operating system. Such a contradiction means you cannot use both them and the Library together in an executable that you distribute.
+
+7. You may place library facilities that are a work based on the Library side-by-side in a single library together with other library facilities not covered by this License, and distribute such a combined library, provided that the separate distribution of the work based on the Library and of the other library facilities is otherwise permitted, and provided that you do these two things:
+
+     a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities. This must be distributed under the terms of the Sections above.
+
+     b) Give prominent notice with the combined library of the fact that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+8. You may not copy, modify, sublicense, link with, or distribute the Library except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense, link with, or distribute the Library is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+9. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Library or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Library (or any work based on the Library), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Library or works based on it.
+
+10. Each time you redistribute the Library (or any work based on the Library), the recipient automatically receives a license from the original licensor to copy, distribute, link with or modify the Library subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties with this License.
+
+11. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Library at all. For example, if a patent license would not permit royalty-free redistribution of the Library by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply, and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+12. If the distribution and/or use of the Library is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Library under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+13. The Free Software Foundation may publish revised and/or new versions of the Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Library does not specify a license version number, you may choose any version ever published by the Free Software Foundation.
+
+14. If you wish to incorporate parts of the Library into other free programs whose distribution conditions are incompatible with these, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Libraries
+
+If you develop a new library, and you want it to be of the greatest possible use to the public, we recommend making it free software that everyone can redistribute and change. You can do so by permitting redistribution under these terms (or, alternatively, under the terms of the ordinary General Public License).
+
+To apply these terms, attach the following notices to the library. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+     one line to give the library's name and an idea of what it does.
+     Copyright (C) year  name of author
+
+     This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your option) any later version.
+
+     This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+
+     You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the library, if necessary. Here is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in
+the library `Frob' (a library for tweaking knobs) written
+by James Random Hacker.
+
+signature of Ty Coon, 1 April 1990
+Ty Coon, President of Vice
+That's all there is to it!

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -9,6 +9,13 @@ precedence = "aggregate"
 SPDX-FileCopyrightText = "No rights reserved"
 SPDX-License-Identifier = "CC0-1.0"
 
+# This may not be entirely correct; some patches contain copyrights
+[[annotations]]
+path = ["build-aux/patches/**"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "Flathub Contributors"
+SPDX-License-Identifier = "LGPL-2.1-or-later"
+
 [[annotations]]
 path = ["dist/**", "package.json"]
 precedence = "aggregate"

--- a/build-aux/patches/appstream-compose-default-propagate-custom.patch
+++ b/build-aux/patches/appstream-compose-default-propagate-custom.patch
@@ -1,0 +1,13 @@
+diff --git a/compose/asc-compose.c b/compose/asc-compose.c
+index 0b746ad9..a3050b0e 100644
+--- a/compose/asc-compose.c
++++ b/compose/asc-compose.c
+@@ -101,7 +101,7 @@ asc_compose_init (AscCompose *compose)
+ 	priv->flags = ASC_COMPOSE_FLAG_USE_THREADS | ASC_COMPOSE_FLAG_ALLOW_NET |
+ 		      ASC_COMPOSE_FLAG_VALIDATE | ASC_COMPOSE_FLAG_STORE_SCREENSHOTS |
+ 		      ASC_COMPOSE_FLAG_ALLOW_SCREENCASTS | ASC_COMPOSE_FLAG_PROCESS_FONTS |
+-		      ASC_COMPOSE_FLAG_PROCESS_TRANSLATIONS;
++		      ASC_COMPOSE_FLAG_PROCESS_TRANSLATIONS | ASC_COMPOSE_FLAG_PROPAGATE_CUSTOM;
+ 
+ 	/* the icon policy will initialize with default settings */
+ 	priv->icon_policy = asc_icon_policy_new ();

--- a/build-aux/patches/appstream-compose-lang-symlinks.patch
+++ b/build-aux/patches/appstream-compose-lang-symlinks.patch
@@ -1,0 +1,107 @@
+From 6f6986c333ed9d56c28e5ff419b33fb4eb158bc2 Mon Sep 17 00:00:00 2001
+From: Matthias Klumpp <matthias@tenstral.net>
+Date: Wed, 5 Jun 2024 21:44:01 +0200
+Subject: [PATCH] compose: Allow file discovery even in symlinked directories
+
+This was discovered to be an issue on Flathub with some component
+localizations being placed in symlinked directories.
+
+CC: https://github.com/flathub/flathub/issues/5272
+---
+ compose/asc-directory-unit.c                  | 69 +++++++++++++++----
+ 5 files changed, 65 insertions(+), 21 deletions(-)
+
+diff --git a/compose/asc-directory-unit.c b/compose/asc-directory-unit.c
+index 80698e873..10c9c3de1 100644
+--- a/compose/asc-directory-unit.c
++++ b/compose/asc-directory-unit.c
+@@ -81,11 +81,12 @@ asc_directory_unit_class_init (AscDirectoryUnitClass *klass)
+ }
+ 
+ static gboolean
+-asc_directory_unit_find_files_recursive (GPtrArray *files,
+-					 const gchar *path_orig,
+-					 guint path_orig_len,
+-					 const gchar *path,
+-					 GError **error)
++asc_directory_unit_find_files_recursive_internal (GPtrArray *files,
++						  const gchar *path_orig,
++						  guint path_orig_len,
++						  const gchar *path,
++						  GHashTable *visited_dirs,
++						  GError **error)
+ {
+ 	const gchar *tmp;
+ 	g_autoptr(GDir) dir = NULL;
+@@ -104,14 +105,38 @@ asc_directory_unit_find_files_recursive (GPtrArray *files,
+ 		g_autofree gchar *path_new = NULL;
+ 		path_new = g_build_filename (path, tmp, NULL);
+ 
+-		/* search recursively, don't follow symlinks */
+-		if (g_file_test (path_new, G_FILE_TEST_IS_DIR) &&
+-		    !g_file_test (path_new, G_FILE_TEST_IS_SYMLINK)) {
+-			if (!asc_directory_unit_find_files_recursive (files,
+-								      path_orig,
+-								      path_orig_len,
+-								      path_new,
+-								      error))
++		/* search recursively */
++		if (g_file_test (path_new, G_FILE_TEST_IS_DIR)) {
++			if (g_file_test (path_new, G_FILE_TEST_IS_SYMLINK)) {
++				g_autofree gchar *real_path = realpath (path_new, NULL);
++
++				if (!real_path) {
++					/* error if realpath fails (like memory allocation error or invalid path) */
++					g_set_error (error,
++						     G_FILE_ERROR,
++						     g_file_error_from_errno (errno),
++						     "Failed to resolve real path");
++					return FALSE;
++				}
++
++				/* don't visit paths twice to avoid loops */
++				if (g_hash_table_contains (visited_dirs, real_path))
++					return TRUE;
++
++				g_hash_table_add (visited_dirs, g_steal_pointer (&real_path));
++			} else {
++				if (g_hash_table_contains (visited_dirs, path_new))
++					return TRUE;
++
++				g_hash_table_add (visited_dirs, g_strdup (path_new));
++			}
++
++			if (!asc_directory_unit_find_files_recursive_internal (files,
++									       path_orig,
++									       path_orig_len,
++									       path_new,
++									       visited_dirs,
++									       error))
+ 				return FALSE;
+ 		} else {
+ 			g_ptr_array_add (files, g_strdup (path_new + path_orig_len));
+@@ -121,6 +146,24 @@ asc_directory_unit_find_files_recursive (GPtrArray *files,
+ 	return TRUE;
+ }
+ 
++static gboolean
++asc_directory_unit_find_files_recursive (GPtrArray *files,
++					 const gchar *path_orig,
++					 guint path_orig_len,
++					 const gchar *path,
++					 GError **error)
++{
++	g_autoptr(GHashTable) visited_dirs = NULL;
++	visited_dirs = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
++
++	return asc_directory_unit_find_files_recursive_internal (files,
++								 path_orig,
++								 path_orig_len,
++								 path,
++								 visited_dirs,
++								 error);
++}
++
+ static gboolean
+ asc_directory_unit_open (AscUnit *unit, GError **error)
+ {

--- a/build-aux/patches/appstream-demotion-allowlist.patch
+++ b/build-aux/patches/appstream-demotion-allowlist.patch
@@ -1,0 +1,20 @@
+diff --git a/src/as-validator.c b/src/as-validator.c
+index 849338c7..c4da24af 100644
+--- a/src/as-validator.c
++++ b/src/as-validator.c
+@@ -653,6 +653,15 @@ as_validator_add_override (AsValidator *validator,
+ 		"developer-id-missing",
+ 		/* allow in case a component really doesn't have an active homepage */
+ 		"url-homepage-missing",
++		/* flathub apps often instruct users to follow some additional steps for sandbox-breaking apps */
++		"description-has-plaintext-url",
++		/* we have our own validation for these fields */
++		"component-name-too-long",
++		"summary-too-long",
++		/* this is a breaking change as 1.0.0 allowed this field to be anything */
++		"developer-id-invalid",
++		/* this has not been the case with appstream-glib */
++		"cid-domain-not-lowercase",
+ 		NULL
+ 	};
+ 

--- a/build-aux/patches/asc-hint-tags-silence-some-vague-validation-errors.patch
+++ b/build-aux/patches/asc-hint-tags-silence-some-vague-validation-errors.patch
@@ -1,0 +1,92 @@
+From cd5dd2c083e34456744d0fe7778efccadac67b18 Mon Sep 17 00:00:00 2001
+From: bbhtt <bbhtt.zn0i8@slmail.me>
+Date: Sat, 20 Apr 2024 07:56:19 +0530
+Subject: [PATCH] asc-hint-tags: Silence some vague validation errors during
+ compose
+
+These are either covered by `appstreamcli validate` or by the linter's
+own checks and provide better and clearer error messages.
+
+The following are lowered to INFO:
+
+ * ancient-metadata
+ * metainfo-unknown-type
+ * icon-not-found
+ * metainfo-screenshot-but-no-media
+ * gui-app-without-icon
+ * no-metainfo
+ * no-valid-category
+---
+ compose/asc-hint-tags.c | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/compose/asc-hint-tags.c b/compose/asc-hint-tags.c
+index cf91318e..2dc0feef 100644
+--- a/compose/asc-hint-tags.c
++++ b/compose/asc-hint-tags.c
+@@ -57,7 +57,7 @@ AscHintTagStatic asc_hint_tag_list[] =  {
+ 	},
+ 
+ 	{ "ancient-metadata",
+-	  AS_ISSUE_SEVERITY_WARNING,
++	  AS_ISSUE_SEVERITY_INFO,
+ 	  "The AppStream metadata should be updated to follow a more recent version of the specification.<br/>"
+ 	  "Please consult <a href=\"http://freedesktop.org/software/appstream/docs/chap-Quickstart.html\">the XML quickstart guide</a> for "
+ 	  "more information."
+@@ -99,7 +99,7 @@ AscHintTagStatic asc_hint_tag_list[] =  {
+ 	},
+ 
+ 	{ "metainfo-unknown-type",
+-	  AS_ISSUE_SEVERITY_ERROR,
++	  AS_ISSUE_SEVERITY_INFO,
+ 	  "The component has an unknown type. Please make sure this component type is mentioned in the specification, and that the"
+ 	  "<code>type=</code> property of the component root-node in the MetaInfo XML file does not contain a spelling mistake."
+ 	},
+@@ -158,7 +158,7 @@ AscHintTagStatic asc_hint_tag_list[] =  {
+ 	},
+ 
+ 	{ "icon-not-found",
+-	  AS_ISSUE_SEVERITY_ERROR,
++	  AS_ISSUE_SEVERITY_INFO,
+ 	  "The icon <em>{{icon_fname}}</em> was not found in the archive. This issue can have multiple reasons, "
+ 	  "like the icon being in a wrong directory or not being available in a suitable size (at least 64x64px). "
+ 	  "To make the icon easier to find, place it in <code>/usr/share/icons/hicolor/&lt;size&gt;/apps</code> and ensure the <code>Icon=</code> value"
+@@ -182,7 +182,7 @@ AscHintTagStatic asc_hint_tag_list[] =  {
+ 	},
+ 
+ 	{ "metainfo-screenshot-but-no-media",
+-	  AS_ISSUE_SEVERITY_WARNING,
++	  AS_ISSUE_SEVERITY_INFO,
+ 	  "A screenshot has been found for this component, but apparently it does not have any images or videos defined. "
+ 	  "The screenshot entry has been ignored."
+ 	},
+@@ -255,7 +255,7 @@ AscHintTagStatic asc_hint_tag_list[] =  {
+ 	},
+ 
+ 	{ "gui-app-without-icon",
+-	  AS_ISSUE_SEVERITY_ERROR,
++	  AS_ISSUE_SEVERITY_INFO,
+ 	  "The component is a GUI application (application which has a .desktop file for the XDG menu and <code>Type=Application</code>), "
+ 	  "but we could not find a matching icon for this application."
+ 	},
+@@ -278,7 +278,7 @@ AscHintTagStatic asc_hint_tag_list[] =  {
+ 	},
+ 
+ 	{ "no-valid-category",
+-	  AS_ISSUE_SEVERITY_ERROR,
++	  AS_ISSUE_SEVERITY_INFO,
+ 	  "This software component is no member of any valid category (note that custom categories and toolkit categories like 'Qt' or 'GTK' are ignored)."
+ 	},
+ 
+@@ -288,7 +288,7 @@ AscHintTagStatic asc_hint_tag_list[] =  {
+ 	},
+ 
+ 	{ "no-metainfo",
+-	  AS_ISSUE_SEVERITY_WARNING,
++	  AS_ISSUE_SEVERITY_INFO,
+ 	  "This software component is missing a <a href=\"https://freedesktop.org/software/appstream/docs/chap-Metadata.html#sect-Metadata-GenericComponent\">MetaInfo file</a> "
+ 	  "as metadata source.<br/>"
+ 	  "To synthesize suitable metadata anyway, we took some data from its desktop-entry file.<br/>"
+-- 
+2.44.0
+

--- a/build-aux/patches/compose-seperate-file-read-error.patch
+++ b/build-aux/patches/compose-seperate-file-read-error.patch
@@ -1,0 +1,86 @@
+From e039ac1baf26ead608232caec621a090c960e832 Mon Sep 17 00:00:00 2001
+From: bbhtt <bbhtt.zn0i8@slmail.me>
+Date: Fri, 17 May 2024 21:05:03 +0530
+Subject: [PATCH] compose: Seperate errors for file-read-error if
+ icon/desktop/metainfo
+
+---
+ compose/asc-compose.c   | 10 +++++-----
+ compose/asc-hint-tags.c | 12 +++++++++++-
+ 2 files changed, 16 insertions(+), 6 deletions(-)
+
+diff --git a/compose/asc-compose.c b/compose/asc-compose.c
+index 0b746ad9..38bfbd7a 100644
+--- a/compose/asc-compose.c
++++ b/compose/asc-compose.c
+@@ -1030,7 +1030,7 @@ asc_compose_process_icons (AscCompose *compose,
+ 		if (img_bytes == NULL) {
+ 			asc_result_add_hint (cres,
+ 					     cpt,
+-					     "file-read-error",
++					     "icon-file-read-error",
+ 					     "fname",
+ 					     icon_fname,
+ 					     "msg",
+@@ -1048,7 +1048,7 @@ asc_compose_process_icons (AscCompose *compose,
+ 		if (img == NULL) {
+ 			asc_result_add_hint (cres,
+ 					     cpt,
+-					     "file-read-error",
++					     "icon-file-read-error",
+ 					     "fname",
+ 					     icon_fname,
+ 					     "msg",
+@@ -1454,7 +1454,7 @@ asc_compose_process_task_cb (AscComposeTask *ctask, AscCompose *compose)
+ 		if (mi_bytes == NULL) {
+ 			asc_result_add_hint_by_cid (ctask->result,
+ 						    mi_basename,
+-						    "file-read-error",
++						    "metainfo-file-read-error",
+ 						    "fname",
+ 						    mi_fname,
+ 						    "msg",
+@@ -1587,7 +1587,7 @@ asc_compose_process_task_cb (AscComposeTask *ctask, AscCompose *compose)
+ 						if (de_bytes == NULL) {
+ 							asc_result_add_hint (ctask->result,
+ 									     cpt,
+-									     "file-read-error",
++									     "desktop-file-read-error",
+ 									     "fname",
+ 									     de_fname,
+ 									     "msg",
+@@ -1642,7 +1642,7 @@ asc_compose_process_task_cb (AscComposeTask *ctask, AscCompose *compose)
+ 			if (de_bytes == NULL) {
+ 				asc_result_add_hint_by_cid (ctask->result,
+ 							    de_basename,
+-							    "file-read-error",
++							    "desktop-file-read-error",
+ 							    "fname",
+ 							    de_fname,
+ 							    "msg",
+diff --git a/compose/asc-hint-tags.c b/compose/asc-hint-tags.c
+index cf91318e..f5bdf4c3 100644
+--- a/compose/asc-hint-tags.c
++++ b/compose/asc-hint-tags.c
+@@ -114,7 +114,17 @@ AscHintTagStatic asc_hint_tag_list[] =  {
+ 	  "Unable to read release information from <code>{{path}}</code>. The error message was: {{msg}}."
+ 	},
+ 
+-	{ "file-read-error",
++	{ "desktop-file-read-error",
++	  AS_ISSUE_SEVERITY_ERROR,
++	  "Unable to read data from file <code>{{fname}}</code>: {{msg}}",
++	},
++
++	{ "icon-file-read-error",
++	  AS_ISSUE_SEVERITY_ERROR,
++	  "Unable to read data from file <code>{{fname}}</code>: {{msg}}",
++	},
++
++	{ "metainfo-file-read-error",
+ 	  AS_ISSUE_SEVERITY_ERROR,
+ 	  "Unable to read data from file <code>{{fname}}</code>: {{msg}}",
+ 	},
+-- 
+2.45.0
+

--- a/build-aux/patches/flatpak-builder-appstream-cli-urls.patch
+++ b/build-aux/patches/flatpak-builder-appstream-cli-urls.patch
@@ -1,0 +1,12 @@
+diff --git a/src/builder-manifest.c b/src/builder-manifest.c
+index fa2fb6e2..84e54bbd 100644
+--- a/src/builder-manifest.c
++++ b/src/builder-manifest.c
+@@ -3033,6 +3033,7 @@ builder_manifest_cleanup (BuilderManifest *self,
+               g_print ("Running appstreamcli compose\n");
+               g_print ("Saving screenshots in %s\n", flatpak_file_get_path_cached (media_dir));
+               if (!appstreamcli_compose (error,
++                                         "--no-partial-urls",
+                                          "--prefix=/",
+                                          origin,
+                                          arg_base_url,

--- a/build-aux/patches/flatpak-builder-disable-compressed-downloads.patch
+++ b/build-aux/patches/flatpak-builder-disable-compressed-downloads.patch
@@ -1,0 +1,14 @@
+diff --git a/src/builder-utils.c b/src/builder-utils.c
+index 7c838170..55c4ab62 100644
+--- a/src/builder-utils.c
++++ b/src/builder-utils.c
+@@ -1114,9 +1114,6 @@ builder_download_uri_buffer (GUri           *uri,
+   curl_easy_setopt (session, CURLOPT_WRITEDATA, &write_data);
+   curl_easy_setopt (session, CURLOPT_ERRORBUFFER, error_buffer);
+ 
+-  if (!disable_http_decompression)
+-    curl_easy_setopt (session, CURLOPT_ACCEPT_ENCODING, "");
+-
+   write_data.out = out;
+   write_data.checksums = checksums;
+   write_data.n_checksums = n_checksums;

--- a/build-aux/patches/flatpak-builder-lfs.patch
+++ b/build-aux/patches/flatpak-builder-lfs.patch
@@ -1,0 +1,77 @@
+diff --git a/src/builder-git.c b/src/builder-git.c
+index 64b48eb8..a851438c 100644
+--- a/src/builder-git.c
++++ b/src/builder-git.c
+@@ -578,6 +578,15 @@ builder_git_mirror_repo (const char     *repo_location,
+                     origin, full_ref_mapping, NULL))
+             return FALSE;
+ 
++          g_print ("Fetching LFS assets\n");
++          if (!git (mirror_dir, NULL, 0, error,
++                    "lfs", "fetch", "--all", NULL))
++            {
++              git (mirror_dir, NULL, 0, error,
++                   "lfs", "logs", "last", NULL);
++            }
++
++
+ 	  /* It turns out that older versions of git (at least 2.7.4)
+ 	   * cannot check out a commit unless a real tag/branch points
+ 	   * to it, which is not the case for e.g. gitbug pull requests.
+@@ -606,6 +615,14 @@ builder_git_mirror_repo (const char     *repo_location,
+                     was_shallow ? "--unshallow" : NULL,
+                     NULL))
+             return FALSE;
++
++          g_print ("Fetching LFS assets\n");
++          if (!git (mirror_dir, NULL, 0, error,
++                    "lfs", "fetch", "--all", NULL))
++            {
++              git (mirror_dir, NULL, 0, error,
++                   "lfs", "logs", "last", NULL);
++            }
+         }
+ 
+       if (alternates)
+@@ -708,6 +725,14 @@ builder_git_shallow_mirror_ref (const char     *repo_location,
+             "fetch", "--depth", "1", "origin", full_ref_colon_full_ref, NULL))
+     return FALSE;
+ 
++  if (!git (mirror_dir, NULL, 0, error,
++            "lfs", "fetch", "origin", full_ref, NULL))
++    {
++      git (mirror_dir, NULL, 0, error,
++           "lfs", "logs", "last", NULL);
++      return FALSE;
++    }
++
+   /* Always mirror submodules */
+   current_commit = git_get_current_commit (mirror_dir, ref, FALSE, context, error);
+   if (current_commit == NULL)
+@@ -858,10 +883,19 @@ builder_git_checkout (const char     *repo_location,
+             "config", "--bool", "core.bare", "false", NULL))
+     return FALSE;
+ 
++  if (!git (dest, NULL, 0, error,
++           "lfs", "install", NULL))
++    return FALSE;
++
+   if (!git (dest, NULL, 0, error,
+             "checkout", branch, NULL))
+     return FALSE;
+ 
++  if (!git (dest, NULL, 0, error,
++           "lfs", "checkout", NULL))
++    return FALSE;
++
++
+   if (mirror_flags & FLATPAK_GIT_MIRROR_FLAGS_MIRROR_SUBMODULES)
+     if (!git_extract_submodule (repo_location, dest, branch, context, error))
+       return FALSE;
+@@ -897,4 +931,4 @@ builder_git_get_default_branch (const char *repo_location)
+ 
+   g_debug ("Failed to auto-detect default branch from git output");
+   return g_strdup ("master");
+-}
+\ No newline at end of file
++}


### PR DESCRIPTION
Build the same version of flatpak-builder run on Flathub, to support backported features and CI-specific behaviours.