### PR TITLE
fix: don't wrap test/build logs in revealers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -35,7 +35,7 @@ async function run() {
      */
     if (core.getBooleanInput('run-tests')) {
         for (const manifest of manifests) {
-            core.startGroup(`Testing "${manifest}"...`);
+            core.info(`Testing "${manifest}"`);
 
             try {
                 await flatter.checkApplication(repository, manifest);
@@ -49,8 +49,6 @@ async function run() {
                 core.setFailed(`Testing "${manifest}": ${e.message}`);
             }
 
-            core.endGroup();
-
             if (process.exitCode === core.ExitCode.Failure)
                 return;
         }
@@ -58,15 +56,13 @@ async function run() {
         await flatter.restoreCache(repository);
 
         for (const manifest of manifests) {
-            core.startGroup(`Building "${manifest}"...`);
+            core.info(`Building "${manifest}"`);
 
             try {
                 await flatter.buildApplication(repository, manifest);
             } catch (e) {
                 core.setFailed(`Building "${manifest}": ${e.message}`);
             }
-
-            core.endGroup();
 
             if (process.exitCode === core.ExitCode.Failure)
                 return;


### PR DESCRIPTION
There's little benefit to hiding the only part of the logs really worth investigating, and it takes a long time to load the result, so drop unnecessary revealers.