### PR TITLE
fix: explicitly throw an error on build/test failures

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -144154,6 +144154,7 @@ async function buildApplication(directory, manifest) {
         cacheId = await cache.restoreCache([stateDir], cacheKey);
     }
 
+    // Prepare flatpak-builder arguments
     const builderArgs = [
         `--arch=${core.getInput('arch')}`,
         '--ccache',
@@ -144167,16 +144168,15 @@ async function buildApplication(directory, manifest) {
     if (core.getInput('gpg-sign'))
         builderArgs.push(`--gpg-sign=${core.getInput('gpg-sign')}`);
 
-    try {
-        await exec.exec('flatpak-builder', [
-            ...builderArgs,
-            '_build',
-            manifest,
-        ]);
-    } catch {
-        if (process.exitCode === 42 && builderArgs.includes('--skip-if-unchanged'))
-            process.exitCode = 0;
-    }
+    // Execute build command
+    const exitCode = await exec.exec('flatpak-builder',
+        [...builderArgs, '_build', manifest],
+        {ignoreReturnCode: true});
+
+    if (exitCode === 42 && builderArgs.includes('--skip-if-unchanged'))
+        core.info('No changes and "--skip-if-unchanged" in arguments');
+    else if (exitCode !== 0)
+        throw new Error(`tests failed with exit code ${exitCode}`);
 
     if (!cacheId?.localeCompare(cacheKey, undefined, { sensitivity: 'accent' }))
         await cache.saveCache([stateDir], cacheKey);
@@ -144333,7 +144333,7 @@ async function testApplication(directory, manifest) {
 
     await writeManifest(manifest, testManifest);
 
-    // Build Phase
+    // Prepare flatpak-builder arguments
     const builderArgs = [
         `--arch=${arch}`,
         '--ccache',
@@ -144347,18 +144347,17 @@ async function testApplication(directory, manifest) {
     if (core.getInput('gpg-sign'))
         builderArgs.push(`--gpg-sign=${core.getInput('gpg-sign')}`);
 
+    // Execute test command
     try {
-        const fullCommand = [
-            'xwfb-run --',
-            'flatpak-builder',
-            ...builderArgs,
-            '_build',
-            manifest,
-        ].join(' ');
-        await exec.exec('bash', ['-c', fullCommand]);
-    } catch {
-        if (process.exitCode === 42 && builderArgs.includes('--skip-if-unchanged'))
-            process.exitCode = 0;
+        const testCommand = ['xwfb-run', '--', 'flatpak-builder',
+            ...builderArgs, '_build', manifest].join(' ');
+        const exitCode = await exec.exec('bash', ['-c', testCommand],
+            {ignoreReturnCode: true});
+
+        if (exitCode === 42 && builderArgs.includes('--skip-if-unchanged'))
+            core.info('No changes and "--skip-if-unchanged" in arguments');
+        else if (exitCode !== 0)
+            throw new Error(`tests failed with exit code ${exitCode}`);
     } finally {
         dbusSession.kill();
     }


### PR DESCRIPTION
Since the expected error needs to be caught when flatpak-builder is passed `--skip-if-unchanged` (code 42), catch the exit status and throw an error if it's unexpected.