### PR TITLE
chore: update default test args

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -137557,7 +137557,8 @@ async function testApplication(directory, manifest) {
             '--device=dri',
             '--share=ipc',
             '--share=network',
-            '--socket=x11',
+            '--socket=fallback-x11',
+            '--socket=wayland',
         ],
     };
 

--- a/src/flatter.js
+++ b/src/flatter.js
@@ -365,7 +365,8 @@ async function testApplication(directory, manifest) {
             '--device=dri',
             '--share=ipc',
             '--share=network',
-            '--socket=x11',
+            '--socket=fallback-x11',
+            '--socket=wayland',
         ],
     };
 


### PR DESCRIPTION
Update the default test args to use `--socket=fallback-x11` and `--socket=wayland` instead of `--socket=x11`.