### PR TITLE
fix: revert to using xvfb-run instead of xwfb-run

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -137600,7 +137600,7 @@ async function testApplication(directory, manifest) {
 
     // Execute test command
     try {
-        const testCommand = ['xwfb-run', '--', 'flatpak-builder',
+        const testCommand = ['xvfb-run', '--', 'flatpak-builder',
             ...builderArgs, '_build', manifest].join(' ');
         const exitCode = await exec.exec('bash', ['-c', testCommand],
             {ignoreReturnCode: true});

--- a/src/flatter.js
+++ b/src/flatter.js
@@ -408,7 +408,7 @@ async function testApplication(directory, manifest) {
 
     // Execute test command
     try {
-        const testCommand = ['xwfb-run', '--', 'flatpak-builder',
+        const testCommand = ['xvfb-run', '--', 'flatpak-builder',
             ...builderArgs, '_build', manifest].join(' ');
         const exitCode = await exec.exec('bash', ['-c', testCommand],
             {ignoreReturnCode: true});


### PR DESCRIPTION
`xwfb-run` appears to cause problems for some test suites, so revert to `xvfb-run` for the time being.

closes #151