### PR TITLE
Reintroduce rust-nightly

### DIFF
--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -105,6 +105,30 @@ jobs:
               org.freedesktop.Sdk.Extension.llvm20/aarch64/25.08
               org.freedesktop.Sdk.Extension.rust-stable/aarch64/25.08
 
+          - name: rust-nightly
+            tag: 24.08
+            flathub: >
+              org.freedesktop.Platform/x86_64/24.08
+              org.freedesktop.Sdk/x86_64/24.08
+              org.freedesktop.Platform/aarch64/24.08
+              org.freedesktop.Sdk/aarch64/24.08
+              org.freedesktop.Sdk.Extension.llvm18/x86_64/24.08
+              org.freedesktop.Sdk.Extension.rust-nightly/x86_64/24.08
+              org.freedesktop.Sdk.Extension.llvm18/aarch64/24.08
+              org.freedesktop.Sdk.Extension.rust-nightly/aarch64/24.08
+
+          - name: rust-nightly
+            tag: 25.08
+            flathub: >
+              org.freedesktop.Platform/x86_64/25.08
+              org.freedesktop.Sdk/x86_64/25.08
+              org.freedesktop.Platform/aarch64/25.08
+              org.freedesktop.Sdk/aarch64/25.08
+              org.freedesktop.Sdk.Extension.llvm20/x86_64/25.08
+              org.freedesktop.Sdk.Extension.rust-nightly/x86_64/25.08
+              org.freedesktop.Sdk.Extension.llvm20/aarch64/25.08
+              org.freedesktop.Sdk.Extension.rust-nightly/aarch64/25.08
+
           # GNOME
           #
           # These are images for the GNOME runtime, and those that add a few


### PR DESCRIPTION
I think it should be its own image. Some projects will always require rust-nightly.